### PR TITLE
Fix infinite loop when skipping desktop

### DIFF
--- a/desktop_switcher.ahk
+++ b/desktop_switcher.ahk
@@ -87,7 +87,7 @@ switchDesktopByNumber(targetDesktop)
         return
     }
 
-    if (Abs(CurrentDesktop - targetDesktop) < 2) {
+    if (Abs(CurrentDesktop - targetDesktop) < 10) {
         ; Go right until we reach the desktop we want
         while (CurrentDesktop < targetDesktop) {
             Send ^#{Right}


### PR DESCRIPTION
This might not be the right way to fix, as the root cause should be the wait-for-active loop ending condition might be incorrect. I'm merely fixing this script in short term to allow it to switch to non-adjacent desktops.